### PR TITLE
Cutting off line 29 in blind auction

### DIFF
--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -152,7 +152,7 @@ While this blind auction is almost functionally identical to the blind auction i
 .. literalinclude:: ../examples/auctions/blind_auction.vy
   :language: python
   :lineno-start: 26
-  :lines: 26-29
+  :lines: 26-28
 
 One key difference is that, because Vyper does not allow for dynamic arrays, we
 have limited the number of bids that can be placed by one address to 128 in this

--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -151,8 +151,8 @@ While this blind auction is almost functionally identical to the blind auction i
 
 .. literalinclude:: ../examples/auctions/blind_auction.vy
   :language: python
-  :lineno-start: 22
-  :lines: 22-24
+  :lineno-start: 26
+  :lines: 26-29
 
 One key difference is that, because Vyper does not allow for dynamic arrays, we
 have limited the number of bids that can be placed by one address to 128 in this


### PR DESCRIPTION
In case to declare one key difference between Vyper and Solidity about dynamic arrays, the example code that show in documentation should be lines: 26-29 instead of lines: 22-25.

### What I did
Cut off line 29 from example code
### How I did it
Change 29 to 28
### How to verify it
Nothing
### Description for the changelog
Nothing
### Cute Animal Picture
![Put a link to a cute animal picture inside the parenthesis-->](http://www.cutestpaw.com/wp-content/uploads/2016/01/I-just-want-some-cuddles....jpg)
